### PR TITLE
Fix layout flickering when menu is hidden

### DIFF
--- a/src/components/app-root/app-root.css
+++ b/src/components/app-root/app-root.css
@@ -56,31 +56,16 @@ app-menu {
   transition-duration: 0.4s;
   transition-timing-function: cubic-bezier(0.4,0.0,0.2,1);
   padding: 1rem;
+  width: 200px;
 }
 
-@media only screen and (max-width: 510px){
-  app-menu {
-    width: 510px;
-  }
-  .hide-menu {
-    margin-left: -510px;
-  }
-}
-
-@media only screen and (min-width: 510px){
-  app-menu {
-    width: 200px;
-  }
-  .hide-menu {
-    margin-left: -200px;
-  }
-}
 .show-menu {
   margin-left: 0;
   border-right: 0.1rem solid var(--menu-border-color);
 }
 
 .hide-menu {
+  margin-left: -200px;
   visibility: hidden;
 }
 

--- a/src/components/app-theme/app-theme.css
+++ b/src/components/app-theme/app-theme.css
@@ -68,23 +68,28 @@ legend, label {
 .radio-wrapper {
   display: flex;
   height: 10rem;
-  margin: 1rem;
   border: 1px solid var(--menu-border-color);
+  width: 100%;
+  margin-bottom: 1rem;
 }
 
 .radio-group {
   display: flex;
   align-items: center;
   padding-left: 1.2rem;
-  width: 15rem;
+  width: calc(100% - 10rem);
   min-width: 10rem;
-  max-width: 15rem;
   background: var(--card-bg-color);
   border-right: 1px solid var(--menu-border-color);
 }
 
+form {
+  width: 100%;
+  max-width: 35rem;
+}
+
 fieldset {
-  width: 99%;
+  width: 100%;
   border: 2px solid var(--text-color);
   border-radius: 0.2rem;
 }

--- a/src/components/preview-theme/preview-theme.css
+++ b/src/components/preview-theme/preview-theme.css
@@ -6,6 +6,7 @@ so-preview-theme {
   flex: 1;
   display: flex;
   flex-direction: column;
+  max-width: 10rem;
 }
 
 .sidebar {


### PR DESCRIPTION
- When menu is hidden and we resize
  browser, the smoothing transition used
  to cause layout flickering.
  Fixed the theme width to flex correctly
  to avoid adding breakpoints.